### PR TITLE
mark old versions of liquidsoap conflicting with camlimages >=5.0.5

### DIFF
--- a/packages/liquidsoap/liquidsoap.1.4.0/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.0/opam
@@ -135,6 +135,7 @@ conflicts: [
   "theora" {< "0.3.1"}
   "vorbis" {< "0.7.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 bug-reports: "https://github.com/savonet/liquidsoap/issues"
 dev-repo: "git+https://github.com/savonet/liquidsoap.git"

--- a/packages/liquidsoap/liquidsoap.1.4.1-1/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.1-1/opam
@@ -146,6 +146,7 @@ conflicts: [
   "theora" {< "0.3.1"}
   "vorbis" {< "0.7.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 bug-reports: "https://github.com/savonet/liquidsoap/issues"
 dev-repo: "git+https://github.com/savonet/liquidsoap.git"

--- a/packages/liquidsoap/liquidsoap.1.4.1-2/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.1-2/opam
@@ -149,6 +149,7 @@ conflicts: [
   "theora" {< "0.3.1"}
   "vorbis" {< "0.7.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 extra-files: ["ignore-bash-completion-install-errors.patch" "md5=b43419de6e3225f59a42f330f557e877"]
 bug-reports: "https://github.com/savonet/liquidsoap/issues"

--- a/packages/liquidsoap/liquidsoap.1.4.1/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.1/opam
@@ -135,6 +135,7 @@ conflicts: [
   "theora" {< "0.3.1"}
   "vorbis" {< "0.7.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 bug-reports: "https://github.com/savonet/liquidsoap/issues"
 dev-repo: "git+https://github.com/savonet/liquidsoap.git"

--- a/packages/liquidsoap/liquidsoap.1.4.2/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.2/opam
@@ -147,6 +147,7 @@ conflicts: [
   "theora" {< "0.3.1"}
   "vorbis" {< "0.7.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 bug-reports: "https://github.com/savonet/liquidsoap/issues"
 dev-repo: "git+https://github.com/savonet/liquidsoap.git"

--- a/packages/liquidsoap/liquidsoap.1.4.3/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.3/opam
@@ -146,6 +146,7 @@ conflicts: [
   "theora" {< "0.3.1"}
   "vorbis" {< "0.7.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 bug-reports: "https://github.com/savonet/liquidsoap/issues"
 dev-repo: "git+https://github.com/savonet/liquidsoap.git"

--- a/packages/liquidsoap/liquidsoap.1.4.4/opam
+++ b/packages/liquidsoap/liquidsoap.1.4.4/opam
@@ -141,6 +141,7 @@ conflicts: [
   "theora" {< "0.3.1"}
   "vorbis" {< "0.7.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 bug-reports: "https://github.com/savonet/liquidsoap/issues"
 dev-repo: "git+https://github.com/savonet/liquidsoap.git"

--- a/packages/liquidsoap/liquidsoap.2.0.0/opam
+++ b/packages/liquidsoap/liquidsoap.2.0.0/opam
@@ -132,6 +132,7 @@ conflicts: [
   "theora" {< "0.4.0"}
   "vorbis" {< "0.8.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 build: [
   ["./bootstrap"] {dev}

--- a/packages/liquidsoap/liquidsoap.2.0.0~rc1/opam
+++ b/packages/liquidsoap/liquidsoap.2.0.0~rc1/opam
@@ -132,6 +132,7 @@ conflicts: [
   "theora" {< "0.4.0"}
   "vorbis" {< "0.8.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 build: [
   ["./bootstrap"] {dev}

--- a/packages/liquidsoap/liquidsoap.2.0.1/opam
+++ b/packages/liquidsoap/liquidsoap.2.0.1/opam
@@ -132,6 +132,7 @@ conflicts: [
   "theora" {< "0.4.0"}
   "vorbis" {< "0.8.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 build: [
   ["./bootstrap"] {dev}

--- a/packages/liquidsoap/liquidsoap.2.0.2-1/opam
+++ b/packages/liquidsoap/liquidsoap.2.0.2-1/opam
@@ -131,6 +131,7 @@ conflicts: [
   "theora" {< "0.4.0"}
   "vorbis" {< "0.8.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 build: [
   ["./bootstrap"] {dev}

--- a/packages/liquidsoap/liquidsoap.2.0.2/opam
+++ b/packages/liquidsoap/liquidsoap.2.0.2/opam
@@ -125,6 +125,7 @@ conflicts: [
   "theora" {< "0.4.0"}
   "vorbis" {< "0.8.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 build: [
   ["./bootstrap"] {dev}

--- a/packages/liquidsoap/liquidsoap.2.0.3-1/opam
+++ b/packages/liquidsoap/liquidsoap.2.0.3-1/opam
@@ -128,6 +128,7 @@ conflicts: [
   "theora" {< "0.4.0"}
   "vorbis" {< "0.8.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 build: [
   ["./bootstrap"] {dev}

--- a/packages/liquidsoap/liquidsoap.2.0.3/opam
+++ b/packages/liquidsoap/liquidsoap.2.0.3/opam
@@ -128,6 +128,7 @@ conflicts: [
   "theora" {< "0.4.0"}
   "vorbis" {< "0.8.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 build: [
   ["./bootstrap"] {dev}

--- a/packages/liquidsoap/liquidsoap.2.0.4-1/opam
+++ b/packages/liquidsoap/liquidsoap.2.0.4-1/opam
@@ -129,6 +129,7 @@ conflicts: [
   "theora" {< "0.4.0"}
   "vorbis" {< "0.8.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 build: [
   ["./bootstrap"] {dev}

--- a/packages/liquidsoap/liquidsoap.2.0.4-2/opam
+++ b/packages/liquidsoap/liquidsoap.2.0.4-2/opam
@@ -129,6 +129,7 @@ conflicts: [
   "theora" {< "0.4.0"}
   "vorbis" {< "0.8.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 build: [
   ["./bootstrap"] {dev}

--- a/packages/liquidsoap/liquidsoap.2.0.4/opam
+++ b/packages/liquidsoap/liquidsoap.2.0.4/opam
@@ -129,6 +129,7 @@ conflicts: [
   "theora" {< "0.4.0"}
   "vorbis" {< "0.8.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 build: [
   ["./bootstrap"] {dev}

--- a/packages/liquidsoap/liquidsoap.2.0.5/opam
+++ b/packages/liquidsoap/liquidsoap.2.0.5/opam
@@ -129,6 +129,7 @@ conflicts: [
   "theora" {< "0.4.0"}
   "vorbis" {< "0.8.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 build: [
   ["./bootstrap"] {dev}

--- a/packages/liquidsoap/liquidsoap.2.0.6/opam
+++ b/packages/liquidsoap/liquidsoap.2.0.6/opam
@@ -129,6 +129,7 @@ conflicts: [
   "theora" {< "0.4.0"}
   "vorbis" {< "0.8.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 build: [
   ["./bootstrap"] {dev}

--- a/packages/liquidsoap/liquidsoap.2.0.7/opam
+++ b/packages/liquidsoap/liquidsoap.2.0.7/opam
@@ -129,6 +129,7 @@ conflicts: [
   "theora" {< "0.4.0"}
   "vorbis" {< "0.8.0"}
   "xmlplaylist" {< "0.1.3"}
+  "camlimages" {>= "5.0.5"}
 ]
 build: [
   ["./bootstrap"] {dev}


### PR DESCRIPTION
This should fix revdeps failures for liquidsoaps in https://github.com/ocaml/opam-repository/pull/24924.